### PR TITLE
Refactored DenseMatrixHelpers

### DIFF
--- a/include/BlitzHelpers.hpp
+++ b/include/BlitzHelpers.hpp
@@ -2,17 +2,18 @@
 // See COPYING and LICENSE files at project root for more details.
 
 /**
- * @file DenseMatrixHelpers.hpp
- * @brief Defines a set of utility functions for working with dense matrices.
+ * @file BlitzHelpers.hpp
+ * @brief Defines a set of utility functions for working with blitz arrays
+ * and their matrix and vector aliases.
  */
+#pragma once
+#include "Traits.hpp"
 #include "Types.hpp"
 #include <blitz/array.h>
 #include <cmath>
 #include <cstddef>
-#include <iterator>
 #include <limits>
 #include <stdexcept>
-#include <type_traits>
 
 namespace blitzdg {
     /**
@@ -87,8 +88,7 @@ namespace blitzdg {
     void reshapeMatTo1D(const matrix_type<T>& mat, OutputItr arrItr, bool byRows = true) {
         // Fail at compile time if the type T is not
         // the same as the value type of OutputItr.
-        static_assert(std::is_same<T, 
-        typename std::iterator_traits<OutputItr>::value_type>::value,
+        static_assert(iteratorValueTypeSameAs<OutputItr, T>(),
         "Matrix value type differs from array value type");
         if (byRows) {
             for (index_type i = 0; i < mat.rows(); ++i) {
@@ -117,8 +117,7 @@ namespace blitzdg {
     void reshape1DToMat(InputItr arrItr, matrix_type<T>& mat, bool byRows = true) {
         // Fail at compile time if the type T is not
         // the same as the value type of InputItr.
-        static_assert(std::is_same<T, 
-        typename std::iterator_traits<InputItr>::value_type>::value,
+        static_assert(iteratorValueTypeSameAs<InputItr, T>(),
         "Matrix value type differs from array value type");
         if (byRows) {
             for (index_type i = 0; i < mat.rows(); ++i) {
@@ -142,9 +141,10 @@ namespace blitzdg {
 	 */
 	template <typename T, typename U>
 	void applyIndexMap(const vector_type<T>& vec, const vector_type<U>& map, vector_type<T>& out) {
-		for( index_type i=0; i < map.length(0); i++)
-				out(i) = vec(map(i));
-	}
+		static_assert(isIntegral<U>(), "map value_type is not integral");
+        for (index_type k = 0; k < map.length(0); ++k)
+            out(k) = vec(map(k));
+    }
 
 	/**
 	 * Convert a vector to a blitz matrix.
@@ -167,5 +167,4 @@ namespace blitzdg {
 	void fullToVector(const matrix_type<T>& mat, vector_type<T>& vec, bool byRows = true) {
 		reshapeMatTo1D(mat, vec.begin(), byRows);
 	}
-
 } // namespace blitzdg

--- a/include/Nodes1DProvisioner.hpp
+++ b/include/Nodes1DProvisioner.hpp
@@ -19,18 +19,6 @@ namespace blitzdg {
   /**
    * Provides facilities for the construction of one-dimensional
    * nodes, operators, and geometric factors.
-   * 
-   * Facilities provided include:
-   * <ul>
-   * <li> Construction of one-dimensional nodes over the computational domain based
-   * on Gauss-Jacobi-Lobotto quadrature rules. </li>
-   * 
-   * <li> </li>
-   * 
-   * <li> </li>
-   * 
-   * <li> </li>
-   * </ul>
    */ 
   class Nodes1DProvisioner {
       real_type Min_x;

--- a/include/Traits.hpp
+++ b/include/Traits.hpp
@@ -1,0 +1,128 @@
+// Copyright (C) 2017-2018  Waterloo Quantitative Consulting Group, Inc.
+// See COPYING and LICENSE files at project root for more details.
+
+/**
+ * @file Traits.hpp
+ * @brief Defines a basic set of traits for making compile-time assertions
+ * about numeric types and iterators.
+ */
+#pragma once
+#include <iterator>
+#include <type_traits>
+
+namespace blitzdg {
+	/////////////////////////////////////////////////////////////////////
+	// GENERAL
+	/////////////////////////////////////////////////////////////////////
+    /**
+     * Returns true if T and U are the same type.
+     */
+    template <typename T, typename U>
+    constexpr bool isSame() {
+        return std::is_same<T, U>::value;
+    }
+
+    /**
+     * Returns true if T is an integral numeric type.
+     */
+    template <typename T>
+    constexpr bool isIntegral() {
+        return std::is_integral<T>::value;
+    }
+	
+	/**
+     * Returns true if T is a floating-point numeric type.
+     */
+	template <typename T>
+	constexpr bool isFloatingPoint() {
+		return std::is_floating_point<T>::value;
+	}
+	
+	/**
+	 * Returns true if T is either an integral or floating-point
+	 * numeric type.
+	 */
+	template <typename T>
+	constexpr bool isArithmetic() {
+		return isIntegral<T>() || isFloatingPoint<T>();
+	}
+
+	/////////////////////////////////////////////////////////////////////
+	// ITERATORS
+	/////////////////////////////////////////////////////////////////////
+	/**
+	 * Defines an alias, type, for the value_type of an iterator.
+	 */
+	template <typename Iterator>
+	struct IteratorValueType {
+		using type = typename std::iterator_traits<Iterator>::value_type;
+	};
+
+	/**
+	 * Returns true if Iterator1 and Iterator2 have the same value_type.
+	 */
+	template <typename Iterator1, typename Iterator2>
+	constexpr bool iteratorValueTypesSame() {
+		return std::is_same<
+			typename IteratorValueType<Iterator1>::type,
+			typename IteratorValueType<Iterator2>::type>::value;
+	}
+
+	/**
+	 * Returns true if the value_type of Iterator is the as the type T.
+	 */
+	template <typename Iterator, typename T>
+	constexpr bool iteratorValueTypeSameAs() {
+		return std::is_same<T,
+			typename IteratorValueType<Iterator>::type>::value;
+	}
+
+	/**
+	 * Returns true if Iterator is a random-access iterator.
+	 */
+	template <typename Iterator>
+	constexpr bool randomAccessIterator() {
+		return std::is_same<std::random_access_iterator_tag,
+			typename std::iterator_traits<Iterator>::iterator_category>::value;
+	}
+
+	/**
+	 * Returns true if Iterator is a bidirectional iterator.
+	 */
+	template <typename Iterator>
+	constexpr bool bidirectionalIterator() {
+		return std::is_same<std::bidirectional_iterator_tag,
+			typename std::iterator_traits<Iterator>::iterator_category>::value ||
+			randomAccessIterator<Iterator>();
+	}
+
+	/**
+	 * Returns true if Iterator is a forward iterator.
+	 */
+	template <typename Iterator>
+	constexpr bool forwardIterator() {
+		return std::is_same<std::forward_iterator_tag,
+			typename std::iterator_traits<Iterator>::iterator_category>::value ||
+			bidirectionalIterator<Iterator>();
+	}
+
+	/**
+	 * Returns true if Iterator is an input iterator.
+	 */
+	template <typename Iterator>
+	constexpr bool inputIterator() {
+		return std::is_same<std::input_iterator_tag,
+			typename std::iterator_traits<Iterator>::iterator_category>::value ||
+			forwardIterator<Iterator>();
+	}
+
+	/**
+	 * Returns true if Iterator is an output iterator.
+	 */
+	template <typename Iterator>
+	constexpr bool outputIterator() {
+		return std::is_same<std::output_iterator_tag,
+			typename std::iterator_traits<Iterator>::iterator_category>::value ||
+			forwardIterator<Iterator>();
+	}
+} // namespace blitzdg

--- a/src/CSCMatrix.cpp
+++ b/src/CSCMatrix.cpp
@@ -1,5 +1,5 @@
 #include "CSCMatrix.hpp"
-#include "DenseMatrixHelpers.hpp"
+#include "BlitzHelpers.hpp"
 #include <cmath>
 #include <iomanip>
 #include <limits>

--- a/src/DenseMatrixinverter.cpp
+++ b/src/DenseMatrixinverter.cpp
@@ -2,7 +2,7 @@
 // See COPYING and LICENSE files at project root for more details.
 
 #include "DenseMatrixInverter.hpp"
-#include "DenseMatrixHelpers.hpp"
+#include "BlitzHelpers.hpp"
 #include "Types.hpp"
 #include <string>
 #include <stdexcept>

--- a/src/DirectSolver.cpp
+++ b/src/DirectSolver.cpp
@@ -2,7 +2,7 @@
 // See COPYING and LICENSE files at project root for more details.
 
 #include "DirectSolver.hpp"
-#include "DenseMatrixHelpers.hpp"
+#include "BlitzHelpers.hpp"
 #include "Types.hpp"
 #include <string>
 #include <stdexcept>

--- a/src/EigenSolver.cpp
+++ b/src/EigenSolver.cpp
@@ -2,7 +2,7 @@
 // See COPYING and LICENSE files at project root for more details.
 
 #include "EigenSolver.hpp"
-#include "DenseMatrixHelpers.hpp"
+#include "BlitzHelpers.hpp"
 #include <blitz/array.h>
 #include <iomanip>
 #include <stdexcept>

--- a/src/Nodes1DProvisioner.cpp
+++ b/src/Nodes1DProvisioner.cpp
@@ -3,7 +3,7 @@
 
 #include "Nodes1DProvisioner.hpp"
 #include "CSCMatrix.hpp"
-#include "DenseMatrixHelpers.hpp"
+#include "BlitzHelpers.hpp"
 #include "DenseMatrixInverter.hpp"
 #include "Types.hpp"
 #include <blitz/array.h>

--- a/src/SparseTriplet.cpp
+++ b/src/SparseTriplet.cpp
@@ -1,5 +1,5 @@
 #include "SparseTriplet.hpp" 
-#include "DenseMatrixHelpers.hpp"
+#include "BlitzHelpers.hpp"
 #include <cmath>
 #include <iomanip>
 #include <limits>

--- a/src/advec1d/main.cpp
+++ b/src/advec1d/main.cpp
@@ -13,7 +13,7 @@
 #include "Nodes1DProvisioner.hpp"
 #include "CsvOutputter.hpp"
 #include "Types.hpp"
-#include "DenseMatrixHelpers.hpp"
+#include "BlitzHelpers.hpp"
 #include "Warning.hpp"
 #include "Advec1d.hpp"
 #include "LSERK4.hpp"

--- a/src/poisson1d/Poisson1d.hpp
+++ b/src/poisson1d/Poisson1d.hpp
@@ -7,7 +7,7 @@
  */
 #pragma once
 #include "Nodes1DProvisioner.hpp"
-#include "DenseMatrixHelpers.hpp"
+#include "BlitzHelpers.hpp"
 #include "LinAlgHelpers.hpp"
 #include "Types.hpp"
 #include <string>

--- a/src/test/BlitzHelpersTests.cpp
+++ b/src/test/BlitzHelpersTests.cpp
@@ -1,4 +1,4 @@
-#include "DenseMatrixHelpers.hpp"
+#include "BlitzHelpers.hpp"
 #include "LinAlgHelpers.hpp"
 #include "Types.hpp"
 #include <blitz/array.h>
@@ -19,7 +19,7 @@ namespace blitzdg {
             It(Should_Return_Matrix_Storage_Order) {
                 real_matrix_type rmat(5,3);
                 real_matrix_type cmat(4,2,ColumnMajorArray<2>());
-                cout << "DenseMatrixHelpers: storage order" << endl;
+                cout << "BlitzHelpers: storage order" << endl;
                 Assert::That(isRowMajor(rmat), Equals(true));
                 Assert::That(isColumnMajor(cmat), Equals(true));
             }
@@ -31,7 +31,7 @@ namespace blitzdg {
                         0,-1,-3,2,0,
                         0,0,1,0,0,
                         0,4,2,0,1;
-                cout << "DenseMatrixHelpers: count nonzeros" << endl;
+                cout << "BlitzHelpers: count nonzeros" << endl;
                 Assert::That(countNonzeros(mat), Equals(12));
             }
 
@@ -52,13 +52,13 @@ namespace blitzdg {
                 podCol = 2,3,0,0,0,3,0,-1,0,4,0,4,-3,1,2,0,0,2,0,0,0,6,0,0,1;
                 reshapeMatTo1D(mat, pod.data());
                 podRow -= pod;
-                cout << "DenseMatrixHelpers: full to pod (rowwise)" << endl;
+                cout << "BlitzHelpers: full to pod (rowwise)" << endl;
                 real_type diff = normInf(podRow);
                 Assert::That(diff, Equals(0.0));
 
                 reshapeMatTo1D(mat, pod.data(), false);
                 podCol -= pod;
-                cout << "DenseMatrixHelpers: full to pod (colwise)" << endl;
+                cout << "BlitzHelpers: full to pod (colwise)" << endl;
                 diff = normInf(podCol);
                 Assert::That(diff, Equals(0.0));
             }
@@ -84,14 +84,14 @@ namespace blitzdg {
                 real_matrix_type ret(5,5);
                 reshape1DToMat(pod.data(), ret);
                 mat -= ret;
-                cout << "DenseMatrixHelpers: pod to full (rowwise)" << endl;
+                cout << "BlitzHelpers: pod to full (rowwise)" << endl;
                 real_type diff = normMax(mat);
                 Assert::That(diff, Equals(0.0));
 
                 reshape1DToMat(pod.data(), ret, false);
                 
                 matT -= ret;
-                cout << "DenseMatrixHelpers: pod to full (colwise)" << endl;
+                cout << "BlitzHelpers: pod to full (colwise)" << endl;
                 diff = normMax(matT);
                 Assert::That(diff, Equals(0.0));
             }

--- a/src/test/DirectSolverTests.cpp
+++ b/src/test/DirectSolverTests.cpp
@@ -5,7 +5,7 @@
 #include "DirectSolver.hpp"
 #include "Types.hpp"
 #include <igloo/igloo_alt.h>
-#include <DenseMatrixHelpers.hpp>
+#include <BlitzHelpers.hpp>
 #include <iostream>
 #include <limits>
 

--- a/src/test/TraitsTests.cpp
+++ b/src/test/TraitsTests.cpp
@@ -1,0 +1,124 @@
+// Copyright (C) 2017-2018  Waterloo Quantitative Consulting Group, Inc.
+// See COPYING and LICENSE files at project root for more details.
+
+#include "Traits.hpp"
+#include <igloo/igloo_alt.h>
+#include <iostream>
+#include <iterator>
+#include <forward_list>
+#include <list>
+#include <vector>
+
+using std::cout;
+using std::endl;
+using std::forward_list;
+using std::istream_iterator;
+using std::list;
+using std::ostream_iterator;
+using std::vector;
+
+namespace blitzdg {
+    namespace TraitsTests {
+        using namespace igloo;
+
+        Describe(Traits_Object) {
+            It(Identifies_Integral_Types) {
+                cout << "Traits: identify integral types" << endl;
+                Assert::That(isIntegral<char>(), Equals(true));
+                Assert::That(isIntegral<short>(), Equals(true));
+                Assert::That(isIntegral<int>(), Equals(true));
+                Assert::That(isIntegral<long>(), Equals(true));
+                Assert::That(isIntegral<long long>(), Equals(true));
+                Assert::That(isIntegral<unsigned char>(), Equals(true));
+                Assert::That(isIntegral<signed char>(), Equals(true));
+                Assert::That(isIntegral<unsigned short>(), Equals(true));
+                Assert::That(isIntegral<unsigned int>(), Equals(true));
+                Assert::That(isIntegral<unsigned long>(), Equals(true));
+                Assert::That(isIntegral<unsigned long long>(), Equals(true));
+                Assert::That(isIntegral<float>(), Equals(false));
+                Assert::That(isIntegral<double>(), Equals(false));
+            }
+
+            It(Identifies_Real_Types) {
+                cout << "Traits: identify real types" << endl;
+                Assert::That(isFloatingPoint<float>(), Equals(true));
+                Assert::That(isFloatingPoint<double>(), Equals(true));
+            }
+
+            It(Identifies_Numeric_Types) {
+                cout << "Traits: identify numeric types" << endl;
+                Assert::That(isArithmetic<char>(), Equals(true));
+                Assert::That(isArithmetic<short>(), Equals(true));
+                Assert::That(isArithmetic<int>(), Equals(true));
+                Assert::That(isArithmetic<long>(), Equals(true));
+                Assert::That(isArithmetic<long long>(), Equals(true));
+                Assert::That(isArithmetic<unsigned char>(), Equals(true));
+                Assert::That(isArithmetic<signed char>(), Equals(true));
+                Assert::That(isArithmetic<unsigned short>(), Equals(true));
+                Assert::That(isArithmetic<unsigned int>(), Equals(true));
+                Assert::That(isArithmetic<unsigned long>(), Equals(true));
+                Assert::That(isArithmetic<unsigned long long>(), Equals(true));
+                Assert::That(isArithmetic<float>(), Equals(true));
+                Assert::That(isArithmetic<double>(), Equals(true));
+            }
+
+            It(Identifies_Iterator_Value_Types_Same) {
+                cout << "Traits: iterator value types are the same" << endl;
+                using dItr = vector<double>::iterator;
+                using const_dItr = vector<double>::const_iterator;
+                using iItr = vector<int>::iterator;
+                Assert::That(iteratorValueTypesSame<dItr, dItr>(), Equals(true));
+                Assert::That(iteratorValueTypesSame<const_dItr, dItr>(), Equals(true));
+                Assert::That(iteratorValueTypesSame<iItr, dItr>(), Equals(false));
+            }
+
+            It(Identifies_Iterator_Value_Type_Same_As_Type) {
+                cout << "Traits: iterator value type is same as type" << endl;
+                using dItr = vector<double>::iterator;
+                using const_dItr = vector<double>::const_iterator;
+                using iItr = vector<int>::iterator;
+                Assert::That(iteratorValueTypeSameAs<dItr, double>(), Equals(true));
+                Assert::That(iteratorValueTypeSameAs<const_dItr, double>(), Equals(true));
+                Assert::That(iteratorValueTypeSameAs<iItr, double>(), Equals(false));
+            }
+
+            It(Identifies_Iterator_Categories) {
+                using raItr = vector<int>::iterator;
+                using bdItr = list<int>::iterator;
+                using fwItr = forward_list<int>::iterator;
+                using inItr = istream_iterator<int>::iterator;
+                using otItr = ostream_iterator<int>::iterator;
+                cout << "Traits: is a random-access iterator" << endl;
+                Assert::That(randomAccessIterator<raItr>(), Equals(true));
+                Assert::That(randomAccessIterator<bdItr>(), Equals(false));
+                Assert::That(randomAccessIterator<fwItr>(), Equals(false));
+                Assert::That(randomAccessIterator<inItr>(), Equals(false));
+                Assert::That(randomAccessIterator<otItr>(), Equals(false));
+                cout << "Traits: is a bidirectional iterator" << endl;
+                Assert::That(bidirectionalIterator<bdItr>(), Equals(true));
+                Assert::That(bidirectionalIterator<raItr>(), Equals(true));
+                Assert::That(bidirectionalIterator<fwItr>(), Equals(false));
+                Assert::That(bidirectionalIterator<inItr>(), Equals(false));
+                Assert::That(bidirectionalIterator<otItr>(), Equals(false));
+                cout << "Traits: is a forward iterator" << endl;
+                Assert::That(forwardIterator<fwItr>(), Equals(true));
+                Assert::That(forwardIterator<raItr>(), Equals(true));
+                Assert::That(forwardIterator<bdItr>(), Equals(true));
+                Assert::That(forwardIterator<inItr>(), Equals(false));
+                Assert::That(forwardIterator<otItr>(), Equals(false));
+                cout << "Traits: is a input iterator" << endl;
+                Assert::That(inputIterator<inItr>(), Equals(true));
+                Assert::That(inputIterator<raItr>(), Equals(true));
+                Assert::That(inputIterator<bdItr>(), Equals(true));
+                Assert::That(inputIterator<fwItr>(), Equals(true));
+                Assert::That(inputIterator<otItr>(), Equals(false));
+                cout << "Traits: is a output iterator" << endl;
+                Assert::That(outputIterator<otItr>(), Equals(true));
+                Assert::That(outputIterator<raItr>(), Equals(true));
+                Assert::That(outputIterator<bdItr>(), Equals(true));
+                Assert::That(outputIterator<fwItr>(), Equals(true));
+                Assert::That(outputIterator<inItr>(), Equals(false));
+            }
+        };
+    } // namespace TraitsTests
+} // namespace blitzdg


### PR DESCRIPTION
- Renamed DenseMatrixHelpers to BlitzHelpers.
- Added missing prama once to BlitzHelpers.
- Updated and added static_assert tests in BlitzHelpers.
- Added Traits.hpp that defines a simple set of traits for making compile-time assertions about numeric types and iterators.