### PR TITLE
Add const to the argv argument to fix the compile error below

### DIFF
--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -4,7 +4,7 @@
 #include <igloo/igloo_alt.h>
 #include "Warning.hpp"
 
-int main(const int argc, char **argv)
+int main(const int argc, const char *argv[])
 {
   using namespace igloo;
   blitzdg::printDisclaimer();


### PR DESCRIPTION
The error is:

src/test/main.cpp: In function ‘int main(int, char**)’:
src/test/main.cpp:11:40: error: invalid conversion from ‘char**’ to ‘const char**’ [-fpermissive]
  return TestRunner::RunAllTests(argc, argv);