### PR TITLE
Fix quad handling bugs

### DIFF
--- a/include/VtkOutputter.hpp
+++ b/include/VtkOutputter.hpp
@@ -131,10 +131,11 @@ private:
                     ++nodeId;
                 }
 
-                if (cellTypes[Np] == VTK_QUAD) {
-					std::swap(nodes[1], nodes[3]);
-					std::swap(nodes[1], nodes[2]);
-                }
+				// This seems to make a mess of things in paraview (for N==1?). Probably don't want it.
+                //if (cellTypes[Np] == VTK_QUAD) {
+				//	std::swap(nodes[1], nodes[3]);
+				//	std::swap(nodes[1], nodes[2]);
+                //}
 
 				unstructuredGrid->InsertNextCell(cellTypes[Np], Np, nodes.data());
             }

--- a/src/MeshManager.cpp
+++ b/src/MeshManager.cpp
@@ -101,7 +101,6 @@ namespace blitzdg {
 
     
         for (index_type k=0; k < NumElements; ++k) {
-            std::cout << k << ", " << E2V(NumFaces*k) << "\n";
             // Enforce counter-clockwise ordering of vertices in EToV table.
             real_type ax = Vref(E2V(NumFaces*k)*Dim),   ay = Vref(E2V(NumFaces*k)*Dim+1);
             real_type bx = Vref(E2V(NumFaces*k+1)*Dim), by = Vref(E2V(NumFaces*k+1)*Dim+1);
@@ -110,8 +109,16 @@ namespace blitzdg {
             real_type det = (ax-cx)*(by-cy) - (bx-cx)*(ay-cy);
 
             if (det < 0) {
-                using std::swap;
-                swap(E2V(NumFaces*k+1), E2V(NumFaces*k+2));
+                // Flip the ordering.
+                index_type tmp = E2V(NumFaces*k+1);
+                if (NumFaces == 3) {
+                    E2V(NumFaces*k+1) = E2V(NumFaces*k+2);
+                    E2V(NumFaces*k+2) = tmp;
+                } else if (NumFaces == 4) {
+                    E2V(NumFaces*k+1) = E2V(NumFaces*k+2);
+                    E2V(NumFaces*k+2) = E2V(NumFaces*k+3);
+                    E2V(NumFaces*k+3) = tmp;
+                }
             }
         }
 
@@ -300,11 +307,15 @@ namespace blitzdg {
             if (det < 0) {
                 // Flip the ordering.
                 index_type tmp = E2V(NumFaces*k+1);
-                E2V(NumFaces*k+1) = E2V(NumFaces*k+2);
-                E2V(NumFaces*k+2) = tmp;
+                if (NumFaces == 3) {
+                    E2V(NumFaces*k+1) = E2V(NumFaces*k+2);
+                    E2V(NumFaces*k+2) = tmp;
+                } else if (NumFaces == 4) {
+                    E2V(NumFaces*k+1) = E2V(NumFaces*k+3);
+                    E2V(NumFaces*k+3) = tmp;
+                }
             }
         }
-
 
         buildConnectivity();
 

--- a/src/QuadNodesProvisioner.cpp
+++ b/src/QuadNodesProvisioner.cpp
@@ -730,7 +730,7 @@ namespace blitzdg {
 
 		index_type count = 0;
 
-		index_matrix_type counter(N+1,N+1);
+		index_matrix_type counter(N+1, N+1);
 		counter = -1; // -1 == 'No Value'
 
 		for (index_type n=0; n < N+1; ++n) {
@@ -754,7 +754,7 @@ namespace blitzdg {
 		for (index_type n=0; n < N; ++n) {
 			for (index_type m=0; m < N; ++m) {
 				index_type v1 = counter(n,m), v2 = counter(n,m+1),
-					v3 = counter(n+1, m), v4 = counter(n+1,m+1);
+					v3 = counter(n+1, m+1), v4 = counter(n+1,m);
 
 				index_vector_type quad1234(4);
 				quad1234 = v1,v2,v3,v4;


### PR DESCRIPTION
-Remove debug cout.
-Handle det>0 enforcement for both tris and quads separately in MeshManager. 
-Fix splitElements bug in Quads provisioner (walk the quad in correct order so at to not zig-zag).